### PR TITLE
Added config option "suppress-session-update-info"

### DIFF
--- a/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
+++ b/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
@@ -100,7 +100,9 @@ public class StandaloneMain {
             try {
                 // Update the session
                 sessionManager.updateSession(sessionInfo);
-                sessionManager.logger().info("Updated session!");
+                if(!config.suppressSessionUpdateInfo()){
+                    sessionManager.logger().info("Updated session!");
+                }
             } catch (SessionUpdateException e) {
                 sessionManager.logger().error("Failed to update session", e);
             }

--- a/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
+++ b/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
@@ -100,7 +100,9 @@ public class StandaloneMain {
             try {
                 // Update the session
                 sessionManager.updateSession(sessionInfo);
-                if(!config.suppressSessionUpdateInfo()){
+                if (config.suppressSessionUpdateInfo()) {
+                    sessionManager.logger().debug("Updated session!");
+                } else {
                     sessionManager.logger().info("Updated session!");
                 }
             } catch (SessionUpdateException e) {

--- a/bootstrap/standalone/src/main/resources/config.yml
+++ b/bootstrap/standalone/src/main/resources/config.yml
@@ -37,5 +37,5 @@ friend-sync:
 # Enable debug logs
 debug-log: false
 
-# Suppresses "Updated session!" log that can get spamy over time (feature request https://github.com/MCXboxBroadcast/Broadcaster/issues/142)
+# Suppresses "Updated session!" log into debug
 suppress-session-update-info: false

--- a/bootstrap/standalone/src/main/resources/config.yml
+++ b/bootstrap/standalone/src/main/resources/config.yml
@@ -36,3 +36,6 @@ friend-sync:
 
 # Enable debug logs
 debug-log: false
+
+# Suppresses "Updated session!" log that can get spamy over time (feature request https://github.com/MCXboxBroadcast/Broadcaster/issues/142)
+suppress-session-update-info: false

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/StandaloneConfig.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/StandaloneConfig.java
@@ -5,5 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record StandaloneConfig(
     @JsonProperty("session") SessionConfig session,
     @JsonProperty("debug-log") boolean debugLog,
+    @JsonProperty("suppress-session-update-info") boolean suppressSessionUpdateInfo,
     @JsonProperty("friend-sync") FriendSyncConfig friendSync) {
 }


### PR DESCRIPTION
Hey, I saw this one feature request (https://github.com/MCXboxBroadcast/Broadcaster/issues/142) where they wanted a features to disable a log message that could potentially get annoying over time. And since I myself find it quite annoying, I added an option into the config with which you can opt in to disable said message. 