### PR TITLE
Add Slack webhook notifications for when the session expires or an user can't be friended because of restrictions

### DIFF
--- a/bootstrap/geyser/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/geyser/MCXboxBroadcastExtension.java
+++ b/bootstrap/geyser/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/geyser/MCXboxBroadcastExtension.java
@@ -4,6 +4,7 @@ import com.rtm516.mcxboxbroadcast.core.BuildData;
 import com.rtm516.mcxboxbroadcast.core.Logger;
 import com.rtm516.mcxboxbroadcast.core.SessionInfo;
 import com.rtm516.mcxboxbroadcast.core.SessionManager;
+import com.rtm516.mcxboxbroadcast.core.SlackNotificationManager;
 import com.rtm516.mcxboxbroadcast.core.configs.ExtensionConfig;
 import com.rtm516.mcxboxbroadcast.core.exceptions.SessionCreationException;
 import com.rtm516.mcxboxbroadcast.core.exceptions.SessionUpdateException;
@@ -113,7 +114,7 @@ public class MCXboxBroadcastExtension implements Extension {
     private void restart() {
         sessionManager.shutdown();
 
-        sessionManager = new SessionManager(new FileStorageManager(this.dataFolder().toString()), logger);
+        sessionManager = new SessionManager(new FileStorageManager(this.dataFolder().toString()), new SlackNotificationManager(logger, config.slackWebhook()), logger);
 
         // Pull onto another thread so we don't hang the main thread
         sessionManager.scheduledThread().execute(this::createSession);
@@ -125,7 +126,7 @@ public class MCXboxBroadcastExtension implements Extension {
 
         logger.info("Starting MCXboxBroadcast Extension " + BuildData.VERSION);
 
-        sessionManager = new SessionManager(new FileStorageManager(this.dataFolder().toString()), logger);
+        sessionManager = new SessionManager(new FileStorageManager(this.dataFolder().toString()), new SlackNotificationManager(logger, config.slackWebhook()), logger);
 
         // Load the config file
         config = ConfigLoader.load(this, MCXboxBroadcastExtension.class, ExtensionConfig.class);

--- a/bootstrap/geyser/src/main/resources/config.yml
+++ b/bootstrap/geyser/src/main/resources/config.yml
@@ -22,3 +22,22 @@ friend-sync:
 
   # Should we automatically unfollow people that no longer follow us
   auto-unfollow: true
+
+# Slack webhook settings
+slack-webhook:
+  # Should we send a message to a slack webhook when the session is updated
+  enabled: false
+
+  # The webhook url to send the message to
+  webhook-url: ""
+
+  # The message to send when the session is expired and needs to be updated
+  session-expired-message: |
+    <!here> Xbox Session expired, sign in again to update it.
+    
+    Use the following link to sign in: %s
+    Enter the code: %s
+
+  # The message to send when a friend has restrictions in place that prevent them from be friend with our account
+  friend-restriction-message: |
+    %s (%s) has restrictions in place that prevent them from be friend with our account.

--- a/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
+++ b/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.rtm516.mcxboxbroadcast.core.BuildData;
 import com.rtm516.mcxboxbroadcast.core.SessionInfo;
 import com.rtm516.mcxboxbroadcast.core.SessionManager;
+import com.rtm516.mcxboxbroadcast.core.SlackNotificationManager;
 import com.rtm516.mcxboxbroadcast.core.configs.StandaloneConfig;
 import com.rtm516.mcxboxbroadcast.core.exceptions.SessionCreationException;
 import com.rtm516.mcxboxbroadcast.core.exceptions.SessionUpdateException;
@@ -64,7 +65,7 @@ public class StandaloneMain {
 
         logger.setDebug(config.debugLog());
 
-        sessionManager = new SessionManager(new FileStorageManager("./cache"), logger);
+        sessionManager = new SessionManager(new FileStorageManager("./cache"), new SlackNotificationManager(logger, config.slackWebhook()), logger);
 
         sessionInfo = config.session().sessionInfo();
 
@@ -82,7 +83,7 @@ public class StandaloneMain {
         try {
             sessionManager.shutdown();
 
-            sessionManager = new SessionManager(new FileStorageManager("./cache"), logger);
+            sessionManager = new SessionManager(new FileStorageManager("./cache"), new SlackNotificationManager(logger, config.slackWebhook()), logger);
 
             createSession();
         } catch (SessionCreationException | SessionUpdateException e) {

--- a/bootstrap/standalone/src/main/resources/config.yml
+++ b/bootstrap/standalone/src/main/resources/config.yml
@@ -34,6 +34,25 @@ friend-sync:
   # Should we automatically unfollow people that no longer follow us
   auto-unfollow: true
 
+# Slack webhook settings
+slack-webhook:
+  # Should we send a message to a slack webhook when the session is updated
+  enabled: false
+
+  # The webhook url to send the message to
+  webhook-url: ""
+
+  # The message to send when the session is expired and needs to be updated
+  session-expired-message: |
+    <!here> Xbox Session expired, sign in again to update it.
+    
+    Use the following link to sign in: %s
+    Enter the code: %s
+
+  # The message to send when a friend has restrictions in place that prevent them from be friend with our account
+  friend-restriction-message: |
+    %s (%s) has restrictions in place that prevent them from be friend with our account.
+
 # Enable debug logs
 debug-log: false
 

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
@@ -31,6 +31,7 @@ import net.raphimc.minecraftauth.util.OAuthEnvironment;
 import net.raphimc.minecraftauth.util.logging.ILogger;
 
 public class AuthManager {
+    private final SlackNotificationManager slackNotificationManager;
     private final StorageManager storageManager;
     private final Logger logger;
 
@@ -41,10 +42,12 @@ public class AuthManager {
     /**
      * Create an instance of AuthManager
      *
+     * @param slackNotificationManager The Slack notification manager to use for sending messages
      * @param storageManager The storage manager to use for storing data
      * @param logger The logger to use for outputting messages
      */
-    public AuthManager(StorageManager storageManager, Logger logger) {
+    public AuthManager(SlackNotificationManager slackNotificationManager, StorageManager storageManager, Logger logger) {
+        this.slackNotificationManager = slackNotificationManager;
         this.storageManager = storageManager;
         this.logger = logger.prefixed("Auth");
 
@@ -110,6 +113,7 @@ public class AuthManager {
             if (xboxToken == null) {
                 xboxToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.getFromInput(logger, httpClient, new StepMsaDeviceCode.MsaDeviceCodeCallback(msaDeviceCode -> {
                     logger.info("To sign in, use a web browser to open the page " + msaDeviceCode.getVerificationUri() + " and enter the code " + msaDeviceCode.getUserCode() + " to authenticate.");
+                    slackNotificationManager.sendSessionExpiredNotification(msaDeviceCode.getVerificationUri(), msaDeviceCode.getUserCode());
                 }));
             } else if (xboxToken.isExpired()) {
                 xboxToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.refresh(logger, httpClient, xboxToken);

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
@@ -322,6 +322,7 @@ public class FriendManager {
                                 forceUnfollow(entry.getKey());
 
                                 logger.warn("Removed " + entry.getValue() + " (" + entry.getKey() + ") as a friend due to restrictions on their account");
+                                sessionManager.slackNotificationManager().sendFriendRestrictionNotification(entry.getValue(), entry.getKey());
                             } else {
                                 logger.warn("Failed to add " + entry.getValue() + " (" + entry.getKey() + ") as a friend: (" + response.statusCode() + ") " + response.body());
                             }

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManager.java
@@ -35,10 +35,11 @@ public class SessionManager extends SessionManagerCore {
      * Create an instance of SessionManager
      *
      * @param storageManager The storage manager to use for storing data
+     * @param slackNotificationManager The Slack notification manager to use for sending messages
      * @param logger The logger to use for outputting messages
      */
-    public SessionManager(StorageManager storageManager, Logger logger) {
-        super(storageManager, logger.prefixed("Primary Session"));
+    public SessionManager(StorageManager storageManager, SlackNotificationManager slackNotificationManager, Logger logger) {
+        super(storageManager, slackNotificationManager, logger.prefixed("Primary Session"));
         this.scheduledThreadPool = Executors.newScheduledThreadPool(5, new NamedThreadFactory("MCXboxBroadcast Thread"));
         this.subSessionManagers = new HashMap<>();
     }
@@ -99,7 +100,7 @@ public class SessionManager extends SessionManagerCore {
             // Create the sub-session manager for each sub-session
             for (String subSession : finalSubSessions) {
                 try {
-                    SubSessionManager subSessionManager = new SubSessionManager(subSession, this, storageManager.subSession(subSession), logger);
+                    SubSessionManager subSessionManager = new SubSessionManager(subSession, this, storageManager.subSession(subSession), slackNotificationManager, logger);
                     subSessionManager.init();
                     subSessionManager.friendManager().initAutoFriend(this.friendSyncConfig);
                     subSessionManagers.put(subSession, subSessionManager);
@@ -203,7 +204,7 @@ public class SessionManager extends SessionManagerCore {
 
         // Create the sub-session manager
         try {
-            SubSessionManager subSessionManager = new SubSessionManager(id, this, storageManager.subSession(id), logger);
+            SubSessionManager subSessionManager = new SubSessionManager(id, this, storageManager.subSession(id), slackNotificationManager,logger);
             subSessionManager.init();
             subSessionManager.friendManager().initAutoFriend(friendSyncConfig);
             subSessionManagers.put(id, subSessionManager);

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
@@ -40,6 +40,7 @@ public abstract class SessionManagerCore {
     protected final Logger logger;
     protected final Logger coreLogger;
     protected final StorageManager storageManager;
+    protected final SlackNotificationManager slackNotificationManager;
 
     protected RtaWebsocketClient rtaWebsocket;
     protected ExpandedSessionInfo sessionInfo;
@@ -52,9 +53,10 @@ public abstract class SessionManagerCore {
      * Create an instance of SessionManager
      *
      * @param storageManager The storage manager to use for storing data
+     * @param slackNotificationManager The Slack notification manager to use for sending messages
      * @param logger The logger to use for outputting messages
      */
-    public SessionManagerCore(StorageManager storageManager, Logger logger) {
+    public SessionManagerCore(StorageManager storageManager, SlackNotificationManager slackNotificationManager, Logger logger) {
         this.httpClient = Methanol.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
             .followRedirects(HttpClient.Redirect.NORMAL)
@@ -64,8 +66,9 @@ public abstract class SessionManagerCore {
         this.logger = logger;
         this.coreLogger = logger.prefixed("");
         this.storageManager = storageManager;
+        this.slackNotificationManager = slackNotificationManager;
 
-        this.authManager = new AuthManager(storageManager, logger);
+        this.authManager = new AuthManager(slackNotificationManager, storageManager, logger);
 
         this.friendManager = new FriendManager(httpClient, logger, this);
 
@@ -80,6 +83,15 @@ public abstract class SessionManagerCore {
      */
     public FriendManager friendManager() {
         return friendManager;
+    }
+
+    /**
+     * Get the Slack notification manager for this session manager
+     *
+     * @return The Slack notification manager
+     */
+    public SlackNotificationManager slackNotificationManager() {
+        return slackNotificationManager;
     }
 
     /**

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SlackNotificationManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SlackNotificationManager.java
@@ -1,0 +1,58 @@
+package com.rtm516.mcxboxbroadcast.core;
+
+import com.rtm516.mcxboxbroadcast.core.configs.SlackWebhookConfig;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class SlackNotificationManager {
+    private final Logger logger;
+    private final SlackWebhookConfig config;
+
+    public SlackNotificationManager(Logger logger, SlackWebhookConfig config) {
+        this.logger = logger;
+        this.config = config;
+    }
+
+    /**
+     * Sends the Slack notification for when the session is expired and needs to be updated
+     *
+     * @param verificationUri The verification URI to use
+     * @param userCode The user code to use
+     */
+    public void sendSessionExpiredNotification(String verificationUri, String userCode) {
+        sendNotification(config.sessionExpiredMessage().formatted(verificationUri, userCode));
+    }
+
+    /**
+     * Sends the Slack notification for when a friend has restrictions in place that prevent them from be friend with our account
+     *
+     * @param username The username of the user
+     * @param xuid The XUID of the user
+     */
+    public void sendFriendRestrictionNotification(String username, String xuid) {
+        sendNotification(config.friendRestrictionMessage().formatted(username, xuid));
+    }
+
+    private void sendNotification(String message) {
+        if (!config.enabled()) {
+            return;
+        }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(config.webhookUrl()))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("{\"text\": \"" + message + "\"}"))
+                .build();
+
+        try (HttpClient httpClient = HttpClient.newHttpClient()) {
+            httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        } catch (IOException | InterruptedException e) {
+            logger.error("Failed to send a slack notification: %s".formatted(message), e);
+        }
+    }
+
+}

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SlackNotificationManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SlackNotificationManager.java
@@ -45,7 +45,7 @@ public class SlackNotificationManager {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(config.webhookUrl()))
                 .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString("{\"text\": \"" + message + "\"}"))
+                .POST(HttpRequest.BodyPublishers.ofString("{\"text\": \"" + message.replace("\n", "\\n") + "\"}"))
                 .build();
 
         try (HttpClient httpClient = HttpClient.newHttpClient()) {

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SubSessionManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SubSessionManager.java
@@ -18,10 +18,11 @@ public class SubSessionManager extends SessionManagerCore {
      * @param id The id of the sub-session
      * @param parent The parent session manager
      * @param storageManager The storage manager to use for storing data
+     * @param slackNotificationManager The Slack notification manager to use for sending messages
      * @param logger The logger to use for outputting messages
      */
-    public SubSessionManager(String id, SessionManager parent, StorageManager storageManager, Logger logger) {
-        super(storageManager, logger.prefixed("Sub-Session " + id));
+    public SubSessionManager(String id, SessionManager parent, StorageManager storageManager, SlackNotificationManager slackNotificationManager, Logger logger) {
+        super(storageManager, slackNotificationManager, logger.prefixed("Sub-Session " + id));
         this.parent = parent;
     }
 

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/ExtensionConfig.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/ExtensionConfig.java
@@ -6,5 +6,6 @@ public record ExtensionConfig(
     @JsonProperty("remote-address") String remoteAddress,
     @JsonProperty("remote-port") String remotePort,
     @JsonProperty("update-interval") int updateInterval,
-    @JsonProperty("friend-sync") FriendSyncConfig friendSync) {
+    @JsonProperty("friend-sync") FriendSyncConfig friendSync,
+    @JsonProperty("slack-webhook") SlackWebhookConfig slackWebhook) {
 }

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/SlackWebhookConfig.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/SlackWebhookConfig.java
@@ -1,0 +1,10 @@
+package com.rtm516.mcxboxbroadcast.core.configs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SlackWebhookConfig(
+        @JsonProperty("enabled") boolean enabled,
+        @JsonProperty("webhook-url") String webhookUrl,
+        @JsonProperty("session-expired-message") String sessionExpiredMessage,
+        @JsonProperty("friend-restriction-message") String friendRestrictionMessage) {
+}

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/StandaloneConfig.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/StandaloneConfig.java
@@ -6,5 +6,6 @@ public record StandaloneConfig(
     @JsonProperty("session") SessionConfig session,
     @JsonProperty("debug-log") boolean debugLog,
     @JsonProperty("suppress-session-update-info") boolean suppressSessionUpdateInfo,
-    @JsonProperty("friend-sync") FriendSyncConfig friendSync) {
+    @JsonProperty("friend-sync") FriendSyncConfig friendSync,
+    @JsonProperty("slack-webhook") SlackWebhookConfig slackWebhook) {
 }


### PR DESCRIPTION
Hello,

I think the title is descriptive enough on what this PR does, this webhook also works with Discord when using the [Slack-Compatible webhook](https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook) (just add /slack at the end of the webhook URL)

