### PR TITLE
Add logs + fix issue if the websocket fails before onOpen is called

### DIFF
--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/Constants.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/Constants.java
@@ -6,6 +6,7 @@ import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
 import org.cloudburstmc.protocol.bedrock.codec.v827.Bedrock_v827;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 
@@ -44,6 +45,8 @@ public class Constants {
     public static final String PROFILE_SETTINGS = "https://profile.xboxlive.com/users/xuid(%s)/profile/settings?settings=Gamertag";
 
     public static final String GALLERY = "https://persona.franchise.minecraft-services.net/api/v1.0/gallery";
+
+    public static final Duration WEBSOCKET_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
 
     /**
      * Gathered from scraped web requests

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/RtaWebsocketClient.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/RtaWebsocketClient.java
@@ -4,6 +4,7 @@ import com.rtm516.mcxboxbroadcast.core.models.ws.MessageType;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
+import java.util.UUID;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -86,36 +87,41 @@ public class RtaWebsocketClient extends WebSocketClient {
             MessageType type = MessageType.fromValue(((Double) parts[0]).intValue());
             switch (type) {
                 case Subscribe:
-                    logger.debug("RTA Websocket subscribed message: " + message);
+                    logger.debug("RTA Websocket [" + connectionId + "] subscribed: " + message);
                     break;
                 case Unsubscribe:
-                    logger.debug("RTA Websocket unsubscribed message: " + message);
+                    logger.debug("RTA Websocket [" + connectionId + "] unsubscribed: " + message);
                     break;
                 case Event:
-                    logger.debug("RTA Websocket event message: " + message);
+                    logger.debug("RTA Websocket [" + connectionId + "] event: " + message);
                     // Get data json object
                     Map<String, Object> data = (Map<String, Object>) parts[2];
                     if (data.getOrDefault("NotificationType", "").equals("IncomingFriendRequestCountChanged")) {
-                        logger.debug("RTA Websocket friend request message: " + message);
+                        logger.debug("RTA Websocket [" + connectionId + "] friend request: " + message);
                         sessionManager.friendManager().acceptPendingFriendRequests();
                     }
                     break;
                 case Resync:
-                    logger.debug("RTA Websocket resync message: " + message);
+                    logger.debug("RTA Websocket [" + connectionId + "] resync: " + message);
                     break;
                 default:
-                    logger.debug("RTA Websocket unknown message: " + message);
+                    logger.debug("RTA Websocket [" + connectionId + "] unknown: " + message);
                     break;
             }
         }
     }
 
     /**
-     * @see WebSocketClient#onClose(int, String, boolean) 
+     * @see WebSocketClient#onClose(int, String, boolean)
      */
     @Override
     public void onClose(int code, String reason, boolean remote) {
-        logger.debug("RTA Websocket disconnected: " + reason + " (" + code + ")");
+        if (!connectionIdFuture.isDone()) {
+            connectionIdFuture.completeExceptionally(new Exception("RTA Websocket [" + connectionId + "] disconnected before connectionId was received"));
+        }
+
+        String reasonString = reason.isEmpty() && code == 1000 ? "Normal close" : reason;
+        logger.debug("RTA Websocket [" + connectionId + "] disconnected: " + reasonString + " (" + code + ")");
     }
 
     /**
@@ -123,6 +129,6 @@ public class RtaWebsocketClient extends WebSocketClient {
      **/
     @Override
     public void onError(Exception ex) {
-        logger.debug("RTA Websocket error: " + ex.getMessage());
+        logger.error("RTA Websocket [" + connectionId + "] error: " + ex.getMessage(), ex);
     }
 }

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/RtaWebsocketClient.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/RtaWebsocketClient.java
@@ -35,7 +35,7 @@ public class RtaWebsocketClient extends WebSocketClient {
 
     /**
      * A helper method to get the stored connection ID
-     * 
+     *
      * @return The stored connection ID
      */
     public String getConnectionId() {
@@ -48,9 +48,9 @@ public class RtaWebsocketClient extends WebSocketClient {
 
     /**
      * When the web socket connects send the request for the connection ID
-     * 
+     *
      * @see WebSocketClient#onOpen(ServerHandshake)
-     * 
+     *
      * @param serverHandshake The handshake of the websocket instance
      */
     @Override
@@ -61,9 +61,9 @@ public class RtaWebsocketClient extends WebSocketClient {
     /**
      * When we get a message check if it's a connection ID message
      * and handle otherwise ignore it
-     * 
-     * @see WebSocketClient#onMessage(String) 
-     * 
+     *
+     * @see WebSocketClient#onMessage(String)
+     *
      * @param message The UTF-8 decoded message that was received.
      */
     @Override

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
@@ -351,7 +351,7 @@ public abstract class SessionManagerCore {
                 createSession();
                 logger.info("WebSocket session reconnected");
             } catch (SessionCreationException | SessionUpdateException e) {
-                logger.error(" is dead and hit exception trying to re-create it", e);
+                logger.error("Session is dead and hit exception trying to re-create it", e);
             }
         }
     }

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
@@ -345,11 +345,13 @@ public abstract class SessionManagerCore {
         // Check if the connection is Lost
         if (!rtaIsOpen || !rtcIsOpen) {
             try {
-                logger.warn("[Lost Connection] Connection to websocket lost (RTA Open: " + rtaIsOpen + " RTC Open: " + rtcIsOpen + "). re-creating session...");
+                logger.warn("Connection to websocket lost, re-creating session...");
+                logger.debug("WebSocket status: RTA Open: " + rtaIsOpen + " RTC Open: " + rtcIsOpen);
+
                 createSession();
-                logger.warn("[Lost Connection] Re-connected!");
+                logger.info("WebSocket session reconnected");
             } catch (SessionCreationException | SessionUpdateException e) {
-                logger.error("[Lost Connection] Session is dead and hit exception trying to re-create it", e);
+                logger.error(" is dead and hit exception trying to re-create it", e);
             }
         }
     }
@@ -369,11 +371,11 @@ public abstract class SessionManagerCore {
      * @return The received connection ID
      */
     protected String waitForConnectionId() throws InterruptedException, ExecutionException, TimeoutException {
-        return this.rtaWebsocket.getConnectionIdFuture().get(10, TimeUnit.SECONDS);
+        return this.rtaWebsocket.getConnectionIdFuture().get(Constants.WEBSOCKET_CONNECTION_TIMEOUT.toSeconds(), TimeUnit.MILLISECONDS);
     }
 
     protected void waitForRTCConnection() throws InterruptedException, ExecutionException, TimeoutException {
-        this.rtcWebsocket.onOpenFuture().get(10, TimeUnit.SECONDS);
+        this.rtcWebsocket.onOpenFuture().get(Constants.WEBSOCKET_CONNECTION_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
     }
 
     protected String setupSession(String deviceId) {

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Simple manager to authenticate and create sessions on Xbox
@@ -211,11 +212,11 @@ public abstract class SessionManagerCore {
 
             try {
                 // Wait and get the connection ID from the websocket
-                String connectionId = waitForConnectionId().get();
+                String connectionId = waitForConnectionId();
 
                 // Update the current session connection ID
                 this.sessionInfo.setConnectionId(connectionId);
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 throw new SessionCreationException("Unable to get connectionId for session: " + e.getMessage());
             }
 
@@ -223,8 +224,8 @@ public abstract class SessionManagerCore {
 
             try {
                 // Wait for the RTC websocket to connect
-                waitForRTCConnection().get();
-            } catch (InterruptedException | ExecutionException e) {
+                waitForRTCConnection();
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 throw new SessionCreationException("Unable to connect to WebRTC for session: " + e.getMessage());
             }
         } else {
@@ -338,13 +339,17 @@ public abstract class SessionManagerCore {
      * This should be called before any updates to the session otherwise they might fail
      */
     protected void checkConnection() {
-        if ((this.rtaWebsocket != null && !rtaWebsocket.isOpen()) || (this.rtcWebsocket != null && !rtcWebsocket.isOpen())) {
+        boolean rtaIsOpen = this.rtaWebsocket != null && this.rtaWebsocket.isOpen();
+        boolean rtcIsOpen = this.rtcWebsocket != null && this.rtcWebsocket.isOpen();
+
+        // Check if the connection is Lost
+        if (!rtaIsOpen || !rtcIsOpen) {
             try {
-                logger.info("Connection to websocket lost, re-creating session...");
+                logger.warn("[Lost Connection] Connection to websocket lost (RTA Open: " + rtaIsOpen + " RTC Open: " + rtcIsOpen + "). re-creating session...");
                 createSession();
-                logger.info("Re-connected!");
+                logger.warn("[Lost Connection] Re-connected!");
             } catch (SessionCreationException | SessionUpdateException e) {
-                logger.error("Session is dead and hit exception trying to re-create it", e);
+                logger.error("[Lost Connection] Session is dead and hit exception trying to re-create it", e);
             }
         }
     }
@@ -363,12 +368,12 @@ public abstract class SessionManagerCore {
      *
      * @return The received connection ID
      */
-    protected Future<String> waitForConnectionId() {
-        return this.rtaWebsocket.getConnectionIdFuture();
+    protected String waitForConnectionId() throws InterruptedException, ExecutionException, TimeoutException {
+        return this.rtaWebsocket.getConnectionIdFuture().get(10, TimeUnit.SECONDS);
     }
 
-    protected Future<Void> waitForRTCConnection() {
-        return this.rtcWebsocket.onOpenFuture();
+    protected void waitForRTCConnection() throws InterruptedException, ExecutionException, TimeoutException {
+        this.rtcWebsocket.onOpenFuture().get(10, TimeUnit.SECONDS);
     }
 
     protected String setupSession(String deviceId) {

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/webrtc/RtcWebsocketClient.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/webrtc/RtcWebsocketClient.java
@@ -74,7 +74,6 @@ public class RtcWebsocketClient extends WebSocketClient {
         this.scheduledExecutorService = scheduledExecutorService;
         this.sessionManager = sessionManager;
 
-
         this.activeSessions = new HashMap<>();
         this.candidateHarvesters = new ArrayList<>();
     }

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/webrtc/RtcWebsocketClient.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/webrtc/RtcWebsocketClient.java
@@ -41,6 +41,8 @@ public class RtcWebsocketClient extends WebSocketClient {
     }
 
     private final Logger logger;
+    private final String requestId;
+    private final String rtaConnectionId;
     private final SessionInfo sessionInfo;
     private final ScheduledExecutorService scheduledExecutorService;
     private final Map<String, PeerSession> activeSessions;
@@ -61,14 +63,17 @@ public class RtcWebsocketClient extends WebSocketClient {
     public RtcWebsocketClient(String authenticationToken, ExpandedSessionInfo sessionInfo, Logger logger, ScheduledExecutorService scheduledExecutorService, SessionManagerCore sessionManager) {
         super(URI.create(Constants.RTC_WEBSOCKET_FORMAT.formatted(sessionInfo.getNetherNetId())));
         addHeader("Authorization", authenticationToken);
-        // both seem random
         addHeader("Session-Id", UUID.randomUUID().toString());
-        addHeader("Request-Id", UUID.randomUUID().toString());
 
+        this.requestId = UUID.randomUUID().toString();
+        addHeader("Request-Id", requestId);
+
+        this.rtaConnectionId = sessionInfo.getConnectionId();
         this.logger = logger;
         this.sessionInfo = sessionInfo;
         this.scheduledExecutorService = scheduledExecutorService;
         this.sessionManager = sessionManager;
+
 
         this.activeSessions = new HashMap<>();
         this.candidateHarvesters = new ArrayList<>();
@@ -103,7 +108,7 @@ public class RtcWebsocketClient extends WebSocketClient {
      */
     @Override
     public void onMessage(String message) {
-        logger.debug("RTC Websocket received: " + message);
+        logger.debug("[" + rtaConnectionId + "] RTC Websocket [" + requestId + "] received: " + message);
         WsFromMessage messageWrapper = Constants.GSON.fromJson(message, WsFromMessage.class);
 
         if (messageWrapper.Type() == 2) {
@@ -118,7 +123,7 @@ public class RtcWebsocketClient extends WebSocketClient {
     @Override
     public void send(String text) {
         super.send(text);
-        logger.debug("RTC Websocket sent: " + text);
+        logger.debug("[" + rtaConnectionId + "] RTC Websocket [" + requestId + "] sent: " + text);
     }
 
     private void handleDataAction(BigInteger from, String message) {
@@ -150,7 +155,7 @@ public class RtcWebsocketClient extends WebSocketClient {
     }
 
     public void handleDisconnect(String sessionId) {
-        logger.debug("Disconnecting session: " + sessionId);
+        logger.debug("[" + rtaConnectionId + "] RTC Websocket [" + requestId + "] disconnecting session: " + sessionId);
         activeSessions.remove(sessionId);
     }
 
@@ -185,14 +190,20 @@ public class RtcWebsocketClient extends WebSocketClient {
 
     @Override
     public void onClose(int code, String reason, boolean remote) {
-        heartbeatFuture.cancel(true);
+        if (heartbeatFuture != null) {
+            heartbeatFuture.cancel(true);
+        }
+        if (!onOpenFuture.isDone()) {
+            onOpenFuture.completeExceptionally(new IllegalStateException("RTC Websocket [" + requestId + "] disconnected before onOpen was called"));
+        }
 
-        logger.info("RTC Websocket disconnected: " + reason + " (" + code + ")");
+        String reasonString = reason.isEmpty() && code == 1000 ? "Normal close" : reason;
+        logger.info("[" + rtaConnectionId + "] RTC Websocket [" + requestId + "] disconnected: " + reasonString + " (" + code + ")");
     }
 
     @Override
     public void onError(Exception ex) {
-        logger.info("RTC Websocket error: " + ex.getMessage());
+        logger.error("[" + rtaConnectionId + "] RTC Websocket [" + requestId + "] error: " + ex.getMessage(), ex);
     }
 
     public SessionInfo sessionInfo() {


### PR DESCRIPTION
## What this PR fixes

### 1. Enhanced Logging with WebSocket IDs
- Added connection IDs to all RTA and RTC WebSocket log messages
- Makes it easier to track which events belong to which WebSocket instances during reconnections
- Helps filter and correlate logs when multiple WebSocket connections are created

### 2. Prevent Infinite Hanging on WebSocket Connections
- Added 10-second timeout to `getConnectionIdFuture()` and `onOpenFuture()` calls
- Prevents the system from hanging indefinitely when WebSocket connections fail
- Throws `TimeoutException` that gets properly caught and handled as `SessionCreationException`

### 3. Proper Future Completion on Connection Failures
- Complete futures with exceptions in `onClose()` methods if they haven't completed yet
- Covers the case where WebSockets fail before `onOpen()` is called

### 4. Null Safety Improvements
- Added null check for `heartbeatFuture` before canceling in `RtcWebsocketClient.onClose()`
- Prevents `NullPointerException` when WebSocket closes before heartbeat is established

## Problem Analysis

The root cause was **waiting indefinitely on promise that will not complete**

1. **Initial Disconnect**: RTA WebSocket disconnects (code 1006 - abnormal closure)
2. **Detection**: System detects the disconnection and attempts to recreate the session
3. **Reconnection Failure**: New RTC WebSocket fails with "Connection refused". The onOpen is never called.
4. **Hanging**: The `waitForRTCConnection().get()` call hangs indefinitely waiting for completion that will never happen
5. **Null Pointer**: When the failed RTC WebSocket closes, `heartbeatFuture` is null, causing another error
6. **System Freeze**: The entire websockets logic becomes unresponsive

## Error Logs Example

```
  | velocity | [14:45:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
-- | -- | --
  | velocity | [14:29:40 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTA Websocket event message: [3,0....
-- | -- | --
  |   | Aug 11 15:29:43.570 |   | velocity | [14:29:43 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTC Websocket sent: {"Type":0}
  |   | Aug 11 15:30:02.856 |   | velocity | [14:30:02 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTA Websocket event message: [3,0,....
  |   | Aug 11 15:30:12.884 |   | velocity | [14:30:12 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTA Websocket disconnected: (1006)
  |   | Aug 11 15:30:23.570 |   | velocity | [14:30:23 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTC Websocket sent: {"Type":0}
  |   | Aug 11 15:30:24.862 |   | velocity | [14:30:24 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Connection to websocket lost, re-creating session...
  |   | Aug 11 15:30:25.374 |   | velocity | [14:30:25 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTA Websocket subscribed message: [1,2,0,1,null]
  |   | Aug 11 15:30:25.449 |   | velocity | [14:30:25 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTC Websocket disconnected: (1000)
  |   | Aug 11 15:30:36.655 |   | velocity | [14:30:36 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 15:30:38.586 |   | velocity | [14:30:38 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTC Websocket error: Connection refused
  |   | Aug 11 15:30:38.587 |   | velocity | [14:30:38 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTC Websocket error: Cannot invoke "java.util.concurrent.ScheduledFuture.cancel(boolean)" because "this.heartbeatFuture" is null
  |   | Aug 11 15:35:36.762 |   | velocity | [14:35:36 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 15:40:36.947 |   | velocity | [14:40:36 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 15:41:25.301 |   | velocity | [14:41:25 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] RTA Websocket disconnected: The connection was closed because the other endpoint did not respond with a pong in time. For more information check: https://github.com/TooTallNate/Java-WebSocket/wiki/Lost-connection-detection (1006)
  |   | Aug 11 15:45:37.034 |   | velocity | [14:45:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 15:50:37.139 |   | velocity | [14:50:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 15:55:37.229 |   | velocity | [14:55:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 16:00:37.328 |   | velocity | [15:00:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 16:05:37.513 |   | velocity | [15:05:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 16:10:37.705 |   | velocity | [15:10:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 16:15:37.804 |   | velocity | [15:15:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
  |   | Aug 11 16:20:37.888 |   | velocity | [15:20:37 INFO] [geyser]: [mcxboxbroadcast] [Primary Session] Presence update successful, scheduling presence update in 300 seconds
```
