### PR TITLE
Add Docker Development Environment with Hot Reload + image size optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,7 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/git,java,gradle,eclipse,netbeans,jetbrains+all,visualstudiocode
 
 run/
+
+bootstrap/standalone/config.yml
+bootstrap/standalone/logs/
+bootstrap/standalone/cache/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,5 +94,5 @@ The production image packages the standalone application with all dependencies f
 
 - **Core Library**: Xbox Live integration and session management
 - **Bootstrap Modules**: Different deployment methods (standalone app, Geyser plugin)
-- **Configuration**: YAML-based settings in `config/config.yml`
-- **Storage**: File-based token caching in `config/cache/`
+- **Configuration**: YAML-based settings in `bootstrap/standalone/config.yml`
+- **Storage**: File-based token caching in `bootstrap/standalone/cache/`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,98 @@
+# MCXboxBroadcast Standalone Development Guide
+
+## Prerequisites
+
+- **Docker** and **Docker Compose** (for development environment)
+- **Microsoft/Xbox Live account** (for authentication)
+
+**Note:** Java 21 is no longer required locally as the development environment runs in Docker.
+
+## Quick Start
+
+**Note: Development setup currently supports the standalone application only.**
+
+1. **Clone and setup**
+   ```bash
+   git clone <repository-url>
+   cd Broadcaster
+   ```
+
+2. **Start development with hot-reload**
+   ```bash
+   make watch
+   ```
+
+   This starts the development container in detached mode. To view logs:
+   ```bash
+   make logs-follow
+   ```
+
+   To shut down the container
+   ```bash
+   make down
+   ```
+
+3. **Authenticate** with Microsoft when prompted (follow the browser link and enter the code)
+
+## Development Commands
+
+| Command | Description |
+|---------|-------------|
+| `make watch` | Start development container with hot reload |
+| `make build` | Build the application Docker image |
+| `make build-no-cache` | Build the application Docker image without cache |
+| `make down` | Stop and remove the development container |
+| `make logs` | Show logs from the service (one-time) |
+| `make logs-follow` | Follow logs from the service (continuous) |
+| `make clean` | Clean up containers, networks, and volumes |
+
+### Production Commands
+
+| Command | Description |
+|---------|-------------|
+| `make docker-build` | Build production Docker image |
+| `make docker-build-no-cache` | Build production image without cache |
+| `make docker-run` | Run production container (one-time) |
+
+## Project Structure
+
+```
+Broadcaster/
+├── core/                           # Core MCXboxBroadcast library
+│   └── src/main/java/             # Core Java source code
+├── bootstrap/
+│   ├── geyser/                    # Geyser plugin integration
+│   └── standalone/                # Standalone application
+│       ├── src/main/java/         # Standalone Java source code
+│       ├── config.yml             # Configuration file (created during development)
+│       ├── cache/                 # Runtime cache directory (created during development)
+│       └── logs/                  # Log files (created during development)
+├── build-logic/                   # Gradle build configuration
+└── Makefile                       # Development commands
+```
+
+## Configuration
+
+The application creates and reads `config.yml` in its working directory. This file contains session settings, server information, and feature toggles.
+
+**Important:** During development, edit the config file at `bootstrap/standalone/config.yml` (this file is created automatically when you run `make watch`).
+
+## Production Docker Build
+For production deployments:
+
+```bash
+# Build production Docker image
+make docker-build
+
+# Run the Docker container
+make docker-run
+```
+
+The production image packages the standalone application with all dependencies for deployment.
+
+## Architecture
+
+- **Core Library**: Xbox Live integration and session management
+- **Bootstrap Modules**: Different deployment methods (standalone app, Geyser plugin)
+- **Configuration**: YAML-based settings in `config/config.yml`
+- **Storage**: File-based token caching in `config/cache/`

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,37 @@
+# Development Dockerfile with hot reload support
+FROM eclipse-temurin:21-alpine
+
+# Install required packages for development
+RUN apk add --no-cache git inotify-tools bash
+
+# Create app user
+RUN adduser -h /opt/app -H -D app
+
+# Create directories and set ownership
+RUN mkdir -p /opt/app/src /opt/app/build && \
+    chown -R app:app /opt/app
+
+# Switch to app user
+USER app:app
+
+# Set working directory
+WORKDIR /opt/app
+
+# Copy gradle wrapper and make it executable
+COPY --chown=app:app gradlew gradlew.bat ./
+COPY --chown=app:app gradle/ gradle/
+RUN chmod +x gradlew
+
+# Copy build configuration files
+COPY --chown=app:app settings.gradle.kts build.gradle.kts gradle.properties ./
+COPY --chown=app:app build-logic/ build-logic/
+
+# Download dependencies (this layer will be cached unless build files change)
+RUN ./gradlew dependencies --no-daemon
+
+# Copy the entrypoint script
+COPY --chown=app:app entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Set the entrypoint to run our hot-reload script
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+# MCXboxBroadcast Makefile (Multi-stage Docker Build)
+# Variables
+IMAGE_NAME = mcxboxbroadcast-standalone
+
+# Default target
+.PHONY: help
+help:
+	@echo "Development:"
+	@echo "  watch                    - Start development server with hot reload"
+	@echo "  build                    - Build the application"
+	@echo "  run                      - Run the application (after building)"
+	@echo "  down                     - Stop and remove the service"
+	@echo "  logs                     - Show logs from the service"
+	@echo "  logs-follow              - Follow logs from the service"
+	@echo "  shell                    - Open a shell in the container"
+	@echo "  clean                    - Clean build artifacts"
+	@echo ""
+	@echo "Production:"
+	@echo "  docker-build             - Build production Docker image"
+	@echo "  docker-build-no-cache    - Build production image without cache"
+	@echo "  docker-run               - Run production container (one-time)"
+
+# =============================================================================
+# Development Targets
+# =============================================================================
+
+# Build the service
+.PHONY: build
+build:
+	@echo "Building MCXboxBroadcast service..."
+	docker compose build
+
+.PHONY: build-no-cache
+build-no-cache:
+	@echo "Building MCXboxBroadcast service without cache..."
+	docker compose build --no-cache
+
+# Start development container with hot reload
+.PHONY: watch
+watch:
+	@echo "Starting development container with hot reload..."
+	docker compose up -d
+	@echo "Run make logs-follow to see logs"
+
+# Stop and remove the service
+.PHONY: down
+down:
+	@echo "Stopping and removing MCXboxBroadcast service..."
+	docker compose down
+
+# Show logs
+.PHONY: logs
+logs:
+	docker compose logs
+
+# Follow logs
+.PHONY: logs-follow
+logs-follow:
+	docker compose logs -f
+
+# Clean up
+.PHONY: clean
+clean:
+	@echo "Cleaning up containers, networks, and volumes..."
+	docker compose down -v --remove-orphans
+
+# =============================================================================
+# Production Docker Targets
+# =============================================================================
+
+.PHONY: docker-build
+docker-build:
+	docker build -t $(IMAGE_NAME):latest -f ./bootstrap/standalone/Dockerfile .
+
+.PHONY: docker-build-no-cache
+docker-build-no-cache:
+	docker build --no-cache -t $(IMAGE_NAME):latest -f ./bootstrap/standalone/Dockerfile .
+
+.PHONY: docker-run
+docker-run:
+	docker run --rm -it -v ./config:/opt/app/config $(IMAGE_NAME):latest

--- a/bootstrap/standalone/Dockerfile
+++ b/bootstrap/standalone/Dockerfile
@@ -1,16 +1,49 @@
-FROM eclipse-temurin:21-alpine
+# Build stage
+FROM eclipse-temurin:21-alpine AS builder
 
+# Install required packages for building
+RUN apk add --no-cache git
+
+# Set working directory
+WORKDIR /app
+
+# Copy gradle wrapper and build files first (for better caching)
+COPY gradlew gradlew.bat ./
+COPY gradle/ gradle/
+COPY settings.gradle.kts build.gradle.kts gradle.properties ./
+COPY build-logic/ build-logic/
+
+# Copy source code and build files
+COPY core/ core/
+COPY bootstrap/ bootstrap/
+
+# Make gradlew executable
+RUN chmod +x gradlew
+
+# Build the application
+RUN ./gradlew :bootstrap-standalone:shadowJar --no-daemon
+
+# Runtime stage
+FROM eclipse-temurin:21-alpine as runtime
+
+# Set up permissions for /tmp
 RUN chmod 777 -R /tmp && chmod o+t -R /tmp
 
+# Create app user
 RUN adduser -h /opt/app -H -D app
 
+# Create directories and set ownership
 RUN mkdir -p /opt/app/config && \
     chown -R app:app /opt/app
 
+# Switch to app user
 USER app:app
 
+# Set working directory
 WORKDIR /opt/app/config
 
-COPY bootstrap/standalone/build/libs/MCXboxBroadcastStandalone.jar /opt/app/MCXboxBroadcastStandalone.jar
+# Copy the built JAR from builder stage
+COPY --from=builder /app/bootstrap/standalone/build/libs/MCXboxBroadcastStandalone.jar /opt/app/MCXboxBroadcastStandalone.jar
 
+# Run the application
 CMD ["java", "-jar", "/opt/app/MCXboxBroadcastStandalone.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  mcxboxbroadcast:
+    container_name: mcxboxbroadcast-standalone-dev
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    restart: unless-stopped
+    volumes:
+      - ./core:/opt/app/core
+      - ./bootstrap:/opt/app/bootstrap
+      - ./build.gradle.kts:/opt/app/build.gradle.kts
+      - ./settings.gradle.kts:/opt/app/settings.gradle.kts
+      - ./gradle.properties:/opt/app/gradle.properties

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Set the working directory
+cd /opt/app
+
+echo "Initial build..."
+# Perform an initial build to ensure everything is ready
+./gradlew :bootstrap-standalone:assemble --no-daemon
+
+# Start the application in a loop
+while true; do
+  echo "Starting application..."
+  # Run the application in the background and store its PID
+  ./gradlew :bootstrap-standalone:run --no-daemon &
+  PID=$!
+
+  echo "Application started with PID $PID. Watching for file changes..."
+
+  # Watch for changes in the source directories.
+  inotifywait -q -r -e modify,create,delete,move \
+    ./core/src \
+    ./bootstrap/standalone/src
+
+  echo "File change detected! Restarting application..."
+  # Kill the previous application process before looping
+  kill $PID
+  # Wait for the process to be fully killed
+  wait $PID 2>/dev/null
+done


### PR DESCRIPTION
## Changes

- **Added docker-compose setup** with hot reload for faster local development
- **Created DEVELOPMENT.md** to help new contributors get started quickly  
- **Added Makefile** with common commands (`make watch`, `make build`, `make logs`, ...)
- **Optimized Docker images** using multi-stage builds for smaller production images

## Quick Start
```bash
make watch    # Start dev environment with hot reload
make logs     # View application logs
make down     # Stop development container
```

New developers can now contribute with just Docker installed - no local Java setup required.