### PR TITLE
Recreate the websocket session when XBL device token get updated

### DIFF
--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
@@ -39,6 +39,8 @@ public class AuthManager {
     private StepXblSisuAuthentication.XblSisuTokens xboxToken;
     private XboxTokenInfo xboxTokenInfo;
     private String playfabSessionTicket;
+    private Runnable onDeviceTokenRefreshCallback;
+
 
     /**
      * Create an instance of AuthManager
@@ -80,15 +82,19 @@ public class AuthManager {
     private void initialise() {
         HttpClient httpClient = MinecraftAuth.createHttpClient();
 
-        // Load in cache.json if we haven't loaded one from the old auth token
-        try {
-            String cacheData = storageManager.cache();
-            if (xboxToken == null && !cacheData.isBlank()) xboxToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.fromJson(JsonUtil.parseString(cacheData).getAsJsonObject());
-        } catch (IOException e) {
-            logger.error("Failed to load cache.json", e);
+        // Try to load xboxToken from cache.json if is not already loaded
+        if (xboxToken == null) {
+            try {
+                String cacheData = storageManager.cache();
+                if (!cacheData.isBlank()) xboxToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.fromJson(JsonUtil.parseString(cacheData).getAsJsonObject());
+            } catch (Exception e) {
+                logger.error("Failed to load cache.json", e);
+            }
         }
 
         try {
+            String oldDeviceTokenId = (xboxToken != null) ? xboxToken.getInitialXblSession().getXblDeviceToken().getDeviceId() : null;
+
             // Get the XSTS token or refresh it if it's expired
             if (xboxToken == null) {
                 xboxToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.getFromInput(logger, httpClient, new StepMsaDeviceCode.MsaDeviceCodeCallback(msaDeviceCode -> {
@@ -106,6 +112,16 @@ public class AuthManager {
             xboxTokenInfo = new XboxTokenInfo(xboxToken);
 
             playfabSessionTicket = fetchPlayfabSessionTicket(httpClient);
+
+            // If the device token has changed, run the callback
+            String newDeviceTokenId =  xboxToken.getInitialXblSession().getXblDeviceToken().getDeviceId();
+            if (oldDeviceTokenId != null && newDeviceTokenId != null && !newDeviceTokenId.equals(oldDeviceTokenId)) {
+                logger.debug("Device token has changed");
+                if (onDeviceTokenRefreshCallback != null) {
+                    onDeviceTokenRefreshCallback.run();
+                }
+            }
+
         } catch (Exception e) {
             logger.error("Failed to get/refresh auth token", e);
         }
@@ -138,6 +154,9 @@ public class AuthManager {
      */
     public XboxTokenInfo getXboxToken() {
         if (xboxToken == null || xboxTokenInfo == null || xboxToken.isExpired()) {
+            logger.debug("xboxToken Need Refresh. (xboxToken: " + (xboxToken != null) +
+                    ", xboxTokenInfo: " + (xboxTokenInfo != null) +
+                    ", xboxToken.isExpired: " + (xboxToken != null && xboxToken.isExpired()) + ")");
             initialise();
         }
         return xboxTokenInfo;
@@ -145,6 +164,7 @@ public class AuthManager {
 
     public String getPlayfabSessionTicket() {
         if (playfabSessionTicket == null) {
+            logger.debug("Playfab Session Ticket Need Refresh. (playfabSessionTicket is null)");
             initialise();
         }
         return playfabSessionTicket;
@@ -161,5 +181,14 @@ public class AuthManager {
         } catch (Exception e) {
             logger.error("Failed to update gamertag", e);
         }
+    }
+
+    /**
+     * Set a callback to be executed when the device token has been refreshed.
+     *
+     * @param onDeviceTokenRefreshCallback The callback to execute on device token refresh
+     */
+    public void setOnDeviceTokenRefreshCallback(Runnable onDeviceTokenRefreshCallback) {
+        this.onDeviceTokenRefreshCallback = onDeviceTokenRefreshCallback;
     }
 }

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
@@ -179,6 +179,16 @@ public abstract class SessionManagerCore {
         // Let the user know we are done
         logger.info("Creation of Xbox LIVE session was successful!");
 
+        authManager.setOnDeviceTokenRefreshCallback(() -> {
+            try {
+                logger.debug("Device token refreshed, recreating session...");
+                createSession();
+                logger.debug("Session recreated after device token refresh");
+            } catch (Exception e) {
+                logger.error("Failed to recreate session after device token refresh", e);
+            }
+        });
+
         initialized = true;
     }
 


### PR DESCRIPTION
### Problem

When XBL device tokens refresh, existing RTA websocket connections become partially broken. The websocket remains "connected" but stops receiving `shoulderTaps` from the Xbox Live session directory, causing the Minecraft session to become invisible to friends over time.

### How to Reproduce

1. **Run MCXboxBroadcast and authenticate**
2. **Edit device token expire time** while MCXboxBroadcast is running:
   - Set `initialXblSession.xblDeviceToken.expireTimeMs` to a minute in the future in `cache.json`
3. **Restart MCXboxBroadcast**
4. **Wait for next auth refresh** over the mock expire time
5. **Observe logs**: You'll see new device token authentication, but `shoulderTaps` events will stop being received
6. **Test session visibility**: Friends should initially see the session, but it becomes stale over time

The RTA websocket will eventually receive a 1006 Abnormal Closure, and the session will be restarted. But this can take anywhere from a few minutes to almost an hour (from my own tests)

### Solution

Added simple device token change detection with automatic session recreation:

1. **`AuthManager`**: Added callback mechanism to detect when device tokens change
2. **`SessionManagerCore`**: Set up callback after initial authentication to recreate session when the device token changes  
3. **Session recreation**: Leverages existing `createSession()` flow which properly re-establishes the RTA & RTC websockets with new device credentials
