### PR TITLE
Add standalone command to fully remove friend relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ For the extension version prefix with `/mcxboxbroadcast`
 | `accounts list` | Lists the accounts that are currently in use and their followers count |
 | `accounts add <sub-session-id>` | Adds an account to the list of accounts to use |
 | `accounts remove <sub-session-id>` | Removes an account from the list of accounts to use |
+| `friends remove <xuid>` (Standalone Only) | Removes both friend relationship directions for an XUID |

--- a/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneLoggerImpl.java
+++ b/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneLoggerImpl.java
@@ -99,7 +99,35 @@ public class StandaloneLoggerImpl extends SimpleTerminalConsole implements Logge
                         default -> warn("Unknown accounts command: " + args[0]);
                     }
                 }
-                case "version" -> info("MCXboxBroadcast Standalone " + BuildData.VERSION);
+                case "friends" -> {
+                    if (args.length != 2 || !args[0].equalsIgnoreCase("remove")) {
+                        warn("Usage: friends remove <xuid>");
+                        return;
+                    }
+
+                    String xuid = args[1];
+                    if (xuid.isEmpty() || xuid.chars().anyMatch(character -> character < '0' || character > '9')) {
+                        warn("Invalid XUID '" + xuid + "'. XUIDs must contain only digits.");
+                        return;
+                    }
+
+                    var friendManager = StandaloneMain.sessionManager.friendManager();
+                    String gamertag = friendManager.lastFriendCache().stream()
+                            .filter(person -> xuid.equals(person.xuid))
+                            .map(person -> person.gamertag)
+                            .filter(name -> name != null && !name.isBlank())
+                            .findFirst()
+                            .orElse(null);
+                    String target = "XUID " + xuid + (gamertag == null ? "" : " (" + gamertag + ")");
+
+                    info("Removing all friend relationships for " + target + "...");
+                    try {
+                        friendManager.removeRelationship(xuid);
+                        info("Successfully removed all friend relationships for " + target + ".");
+                    } catch (Exception e) {
+                        error("Failed to remove all friend relationships for " + target + ".", e);
+                    }
+                }                case "version" -> info("MCXboxBroadcast Standalone " + BuildData.VERSION);
                 case "help" -> {
                     info("Available commands:");
                     info("exit - Exit the application");
@@ -108,6 +136,7 @@ public class StandaloneLoggerImpl extends SimpleTerminalConsole implements Logge
                     info("accounts list - List sub-accounts");
                     info("accounts add <sub-session-id> - Add a sub-account");
                     info("accounts remove <sub-session-id> - Remove a sub-account");
+                    info("friends remove <xuid> - Remove both friend relationship directions for an XUID");
                     info("version - Display the version");
                 }
                 default -> warn("Unknown command: " + commandNode);

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
@@ -188,7 +188,7 @@ public class FriendManager {
     public void remove(String xuid, String gamertag) {
         // Try and get the gamertag from the cache if it wasn't provided
         if (gamertag == null) {
-            Optional<FollowerResponse.Person> foundFriend = lastFriendCache.stream().filter(person -> person.xuid.equals(xuid)).findFirst();
+            Optional<FollowerResponse.Person> foundFriend = lastFriendCache().stream().filter(person -> person.xuid.equals(xuid)).findFirst();
             if (foundFriend.isPresent()) {
                 gamertag = foundFriend.get().gamertag;
             } else {
@@ -206,6 +206,44 @@ public class FriendManager {
         callInternalProcess();
     }
 
+    /**
+     * Remove both directions of the relationship for one XUID.
+     *
+     * <p>The follower relationship is removed first so auto-follow cannot immediately
+     * queue the user to be followed again. The outgoing friend relationship is then
+     * removed synchronously so callers can report the real result.</p>
+     *
+     * @param xuid The XUID to remove
+     * @throws Exception If either Xbox Live relationship request fails
+     */
+    public void removeRelationship(String xuid) throws Exception {
+        // Initialize the cache before forceUnfollow updates it.
+        lastFriendCache();
+
+        // Cancel any queued operation for this XUID before performing the explicit cleanup.
+        toAdd.remove(xuid);
+        toRemove.remove(xuid);
+
+        // Remove the incoming follower side first. This is the condition auto-follow checks.
+        forceUnfollow(xuid);
+
+        HttpRequest friendDeleteRequest = HttpRequest.newBuilder()
+                .uri(URI.create(Constants.PEOPLE.formatted(xuid)))
+                .header("Authorization", sessionManager.getTokenHeader())
+                .DELETE()
+                .build();
+        HttpResponse<String> response = httpClient.send(friendDeleteRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 204) {
+            throw new RuntimeException(response.statusCode() + ": " + response.body());
+        }
+
+        // Clear any operation queued during the request and remove stale local state.
+        toAdd.remove(xuid);
+        toRemove.remove(xuid);
+        lastFriendCache().removeIf(person -> person.xuid.equals(xuid));
+        sessionManager.storageManager().playerHistory().clear(xuid);
+    }
     public void init(CoreConfig.FriendSyncConfig friendSyncConfig) {
         shouldAcceptPendingRequests = friendSyncConfig.autoFollow();
 
@@ -505,7 +543,7 @@ public class FriendManager {
         HttpResponse<String> response = httpClient.send(followerDeleteRequest, HttpResponse.BodyHandlers.ofString());
         if (response.statusCode() == 204) {
             // Remove the user from the cache
-            lastFriendCache.removeIf(person -> person.xuid.equals(xuid));
+            lastFriendCache().removeIf(person -> person.xuid.equals(xuid));
 
             sessionManager.storageManager().playerHistory().clear(xuid);
         } else {


### PR DESCRIPTION
## Summary

Adds a Standalone console command:

`friends remove <xuid>`

The command removes both directions of the Xbox friend relationship for the supplied XUID.

## Changes

- Added `friends remove <xuid>` to the Standalone console.
- Uses XUID as the required identifier.
- Validates that the supplied XUID contains only digits.
- Uses a cached gamertag only as optional context in console logs.
- Added clear start, success, and failure logging containing the XUID.
- Added `FriendManager#removeRelationship(String xuid)` to clean up both relationship directions.
- Clears pending friend operations only for the requested XUID.
- Removes stale local friend-cache and player-history data for the requested XUID.
- Added the command to the README.

## Testing

- Built and tested against Standalone build 144.
- Tested manually on Windows using a separate Xbox bot account.
- Confirmed that `friends remove <xuid>` successfully removed both relationship directions.
- Confirmed that the relationship was not immediately recreated with `auto-follow: true`.
- Confirmed that existing Standalone functionality continued operating normally.